### PR TITLE
Add inline code styling with background and border

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -274,11 +274,20 @@ img {
   height: auto;
 }
 
+/* インラインコードのスタイル */
 code {
-  padding: 2px 5px;
+  padding: 3px 6px;
+  background: rgba(127, 167, 255, 0.15);
+  border-radius: 4px;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-size: 0.9em;
+  color: #f0c5c9;
+  border: 1px solid rgba(127, 167, 255, 0.25);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
-/* 全て初期値に戻す */
+/* コードブロック内のcodeタグは全て初期値に戻す */
 pre > code {
   all: unset;
 }


### PR DESCRIPTION
インラインコード（pre タグなしの code 要素）に以下のスタイルを追加:
- 背景色（青みがかった半透明）
- ボーダー（青系）
- ボーダー半径
- モノスペースフォント
- 適切なパディングとフォントサイズ
- ピンク系の文字色

コードブロック（pre > code）のスタイルは引き続きリセットされ、
シンタックスハイライトが適用されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)